### PR TITLE
Adds chardet library

### DIFF
--- a/java8-jre/requirements.txt
+++ b/java8-jre/requirements.txt
@@ -3,6 +3,7 @@ backports-abc==0.4
 backports.shutil-get-terminal-size==1.0.0
 boto3>=1.3.1
 botocore>=1.4.25
+chardet==2.3.0
 coverage==3.7.1
 cycler==0.10.0
 Cython==0.24


### PR DESCRIPTION
`chardet` is a helpful library for detecting text encodings based on a byte-order marker if one is present.